### PR TITLE
Add `threadCpuUsage`

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -306,6 +306,37 @@ bare_os_cpu_usage (js_env_t *env, js_callback_info_t *info) {
 }
 
 static js_value_t *
+bare_os_cpu_usage_thread (js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  uv_rusage_t usage;
+  err = uv_getrusage_thread(&usage);
+  assert(err == 0);
+
+  js_value_t *result;
+  err = js_create_object(env, &result);
+  assert(err == 0);
+
+#define V(name, property) \
+  { \
+    uv_timeval_t time = usage.ru_##property; \
+\
+    js_value_t *value; \
+    err = js_create_int64(env, time.tv_sec * 1e6 + time.tv_usec, &value); \
+    assert(err == 0); \
+\
+    err = js_set_named_property(env, result, name, value); \
+    assert(err == 0); \
+  }
+
+  V("user", utime)
+  V("system", stime)
+#undef V
+
+  return result;
+}
+
+static js_value_t *
 bare_os_resource_usage (js_env_t *env, js_callback_info_t *info) {
   int err;
 
@@ -397,7 +428,7 @@ bare_os_memory_usage (js_env_t *env, js_callback_info_t *info) {
 
 #define V(name, property) \
   { \
-    if (stats.property != (size_t) -1) { \
+    if (stats.property != (size_t) - 1) { \
       js_value_t *value; \
       err = js_create_int64(env, stats.property, &value); \
       assert(err == 0); \
@@ -843,6 +874,7 @@ bare_os_exports (js_env_t *env, js_value_t *exports) {
   V("kill", bare_os_kill)
   V("availableParallelism", bare_os_available_parallelism)
   V("cpuUsage", bare_os_cpu_usage)
+  V("threadCpuUsage", bare_os_cpu_usage_thread)
   V("resourceUsage", bare_os_resource_usage)
   V("memoryUsage", bare_os_memory_usage)
   V("freemem", bare_os_freemem)

--- a/binding.c
+++ b/binding.c
@@ -428,7 +428,7 @@ bare_os_memory_usage (js_env_t *env, js_callback_info_t *info) {
 
 #define V(name, property) \
   { \
-    if (stats.property != (size_t) - 1) { \
+    if (stats.property != (size_t) -1) { \
       js_value_t *value; \
       err = js_create_int64(env, stats.property, &value); \
       assert(err == 0); \

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,10 +39,14 @@ export function endianness(): 'LE' | 'BE'
 
 export function availableParallelism(): number
 
-export function cpuUsage(previous?: { user: number; system: number }): {
+export interface CpuUsage {
   user: number
   system: number
 }
+
+export function cpuUsage(previous?: CpuUsage): CpuUsage
+
+export function threadCpuUsage(previous?: CpuUsage): CpuUsage
 
 export function resourceUsage(): {
   userCPUTime: number

--- a/index.js
+++ b/index.js
@@ -58,6 +58,19 @@ exports.cpuUsage = function cpuUsage(previous) {
   return current
 }
 
+exports.threadCpuUsage = function threadCpuUsage(previous) {
+  const current = binding.threadCpuUsage()
+
+  if (previous) {
+    return {
+      user: current.user - previous.user,
+      system: current.system - previous.system
+    }
+  }
+
+  return current
+}
+
 exports.resourceUsage = binding.resourceUsage
 exports.memoryUsage = binding.memoryUsage
 exports.freemem = binding.freemem

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bare-os",
-  "version": "3.4.0",
+  "version": "3.4.0-0",
   "description": "Operating system utilities for Javascript",
   "exports": {
     ".": {

--- a/test.js
+++ b/test.js
@@ -73,6 +73,10 @@ test('cpu usage', (t) => {
   t.comment(os.cpuUsage())
 })
 
+test('thread cpu usage', (t) => {
+  t.comment(os.threadCpuUsage())
+})
+
 test('resource usage', (t) => {
   t.comment(os.resourceUsage())
 })


### PR DESCRIPTION
I was able to confirm that `uv_getrusage_thread` works on non-rooted Android devices. 
![Untitled](https://github.com/user-attachments/assets/717b5106-82f2-41c2-bd50-69a0b228c940)

The new API follows: https://github.com/nodejs/node/pull/56467