### PR TITLE
Add optional `uid` arg to `os.userInfo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ Returns an object containing network interfaces that have been assigned a networ
 
 Sends `signal` to the process identified by `pid`. `signal` can be a string or a number. Defaults to `'SIGTERM'`.
 
-#### `const info = os.userInfo()`
+#### `const info = os.userInfo([uid])`
 
-Returns information about the current user. The returned object has the following properties:
+Returns information about a current user. The `uid` value defaults to the current effective uid. The returned object has the following properties:
 
 - `uid` - The user ID.
 - `gid` - The group ID.

--- a/binding.c
+++ b/binding.c
@@ -258,8 +258,29 @@ static js_value_t *
 bare_os_user_info(js_env_t *env, js_callback_info_t *info) {
   int err;
 
+  size_t argc = 1;
+  js_value_t *argv[1];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 1);
+
+  bool uid_undefined;
+  err = js_is_undefined(env, argv[0], &uid_undefined);
+  assert(err == 0);
+
   uv_passwd_t pwd;
-  err = uv_os_get_passwd(&pwd);
+  if (uid_undefined) {
+    err = uv_os_get_passwd(&pwd);
+  } else {
+    uint32_t uid;
+    err = js_get_value_uint32(env, argv[0], &uid);
+    assert(err == 0);
+
+    err = uv_os_get_passwd2(&pwd, uid);
+  }
+
   if (err != 0) {
     err = js_throw_error(env, uv_err_name(err), uv_strerror(err));
     assert(err == 0);

--- a/binding.c
+++ b/binding.c
@@ -264,7 +264,7 @@ bare_os_user_info(js_env_t *env, js_callback_info_t *info) {
   err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
   assert(err == 0);
 
-  assert(argc == 1);
+  assert(argc == 0 || argc == 1);
 
   bool uid_undefined;
   err = js_is_undefined(env, argv[0], &uid_undefined);

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,7 @@ export interface UserInfo {
   shell: string | null
 }
 
-export function userInfo(): UserInfo
+export function userInfo(uid?: number): UserInfo
 
 export interface GroupInfo {
   groupname: string

--- a/index.js
+++ b/index.js
@@ -28,12 +28,7 @@ exports.chdir = binding.chdir
 exports.tmpdir = binding.tmpdir
 exports.homedir = binding.homedir
 exports.hostname = binding.hostname
-
-exports.userInfo = function userInfo(uid) {
-  if (typeof uid === 'object') uid = undefined // For Node.js compatibility
-
-  return binding.userInfo(uid)
-}
+exports.userInfo = binding.userInfo
 
 exports.groupInfo = function groupInfo(gid) {
   if (gid === undefined) gid = exports.userInfo().gid

--- a/index.js
+++ b/index.js
@@ -28,7 +28,12 @@ exports.chdir = binding.chdir
 exports.tmpdir = binding.tmpdir
 exports.homedir = binding.homedir
 exports.hostname = binding.hostname
-exports.userInfo = binding.userInfo
+
+exports.userInfo = function userInfo(uid) {
+  if (typeof uid === 'object') uid = undefined // For Node.js compatibility
+
+  return binding.userInfo(uid)
+}
 
 exports.groupInfo = function groupInfo(gid) {
   if (gid === undefined) gid = exports.userInfo().gid

--- a/test.js
+++ b/test.js
@@ -132,13 +132,15 @@ test('cpus', (t) => {
 test('user info', (t) => {
   const defaultInfo = os.userInfo()
 
-  t.alike(os.userInfo(defaultInfo.uid), defaultInfo)
+  if (defaultInfo.uid === -1) t.comment(defaultInfo)
+  else t.alike(os.userInfo(defaultInfo.uid), defaultInfo)
 })
 
 test('group info', (t) => {
   const defaultInfo = os.groupInfo()
 
-  t.alike(os.groupInfo(defaultInfo.gid), defaultInfo)
+  if (defaultInfo === null) t.comment(defaultInfo)
+  else t.alike(os.groupInfo(defaultInfo.gid), defaultInfo)
 })
 
 test('network interfaces', (t) => {

--- a/test.js
+++ b/test.js
@@ -130,11 +130,15 @@ test('cpus', (t) => {
 })
 
 test('user info', (t) => {
-  t.comment(os.userInfo())
+  const defaultInfo = os.userInfo()
+
+  t.alike(os.userInfo(defaultInfo.uid), defaultInfo)
 })
 
 test('group info', (t) => {
-  t.comment(os.groupInfo())
+  const defaultInfo = os.groupInfo()
+
+  t.alike(os.groupInfo(defaultInfo.gid), defaultInfo)
 })
 
 test('network interfaces', (t) => {


### PR DESCRIPTION
For API symmetry with `os.groupInfo`.

A guard was added to ensure compatibility with `os.userInfo` options argument from Node.js.

---

I am not sure if it's a good API change, maybe it would be better to add a new method.