### PR TITLE
Fix memory leak by freeing allocated value in bare_os_get_env

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -1134,6 +1134,8 @@ bare_os_get_env(js_env_t *env, js_callback_info_t *info) {
       assert(err == 0);
 
       free(name);
+      free(value);
+
       return NULL;
     }
 


### PR DESCRIPTION
While reviewing the `bare-os` package, I noticed a potential memory leak in an edge case. It's unlikely to have a significant impact, but I believe it's worth addressing to keep the codebase clean and avoid leaving behind small issues.
