### PR TITLE
Fix hasEnv incorrectly calling getEnv instead of the boolean handler

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -1343,7 +1343,7 @@ bare_os_exports(js_env_t *env, js_value_t *exports) {
   V("setPriority", bare_os_set_priority)
   V("getEnvKeys", bare_os_get_env_keys)
   V("getEnv", bare_os_get_env)
-  V("hasEnv", bare_os_get_env)
+  V("hasEnv", bare_os_has_env)
   V("setEnv", bare_os_set_env)
   V("unsetEnv", bare_os_unset_env)
   V("userInfo", bare_os_user_info)

--- a/test.js
+++ b/test.js
@@ -146,3 +146,21 @@ test('group info', (t) => {
 test('network interfaces', (t) => {
   t.comment(os.networkInterfaces())
 })
+
+test('has env', (t) => {
+  t.plan(5)
+
+  const key = '__BARE_OS_TEST_ENV__'
+
+  t.is(os.hasEnv(key), false)
+  t.is(os.getEnv(key), undefined)
+
+  os.setEnv(key, 'fake_env')
+
+  t.is(os.hasEnv(key), true)
+  t.is(os.getEnv(key), 'fake_env')
+
+  os.unsetEnv(key)
+
+  t.is(os.hasEnv(key), false)
+})


### PR DESCRIPTION
Hey guys! It's me again.

I was exploring the codebase to learn about the project and noticed that `hasEnv` was linked to `bare_os_get_env` in the exports table instead of the dedicated `bare_os_has_env` handler. Opening this PR to fix it, but feel free to close if I missed something.